### PR TITLE
Add hardening for select()

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -67,6 +67,18 @@ _STI int __fortify_FD_ISSET(int __f, fd_set * _FORTIFY_POS0 __s)
 #undef FD_ISSET
 #define FD_ISSET(fd, set) __fortify_FD_ISSET(fd, set)
 
+#ifndef __clang__
+#undef select
+_FORTIFY_FN(select) int select(int nfds, fd_set* readfds,
+                  fd_set* writefds,
+                  fd_set* exceptfds,
+                  struct timeval *timeout){
+	if (nfds > FD_SETSIZE + 1)
+		__builtin_trap();
+	return __orig_select(nfds, readfds, writefds, exceptfds, timeout);
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -78,6 +78,8 @@ RUNTIME_TARGETS= \
 	test_recv_static             \
 	test_recvfrom_dynamic        \
 	test_recvfrom_static         \
+	test_select_dynamic          \
+	test_select_static           \
 	test_send_dynamic            \
 	test_send_static             \
 	test_sendto_dynamic          \

--- a/tests/test_select_dynamic.c
+++ b/tests/test_select_dynamic.c
@@ -1,0 +1,16 @@
+#include "common.h"
+
+#include <sys/select.h>
+
+int main(int argc, char** argv) {
+#if !defined(__clang__)
+  fd_set rfds;
+
+  CHK_FAIL_START
+  select(FD_SETSIZE + argc, &rfds, NULL, NULL, NULL);
+  CHK_FAIL_END
+
+  puts((const char*)&rfds);
+#endif
+  return ret;
+}

--- a/tests/test_select_static.c
+++ b/tests/test_select_static.c
@@ -1,0 +1,16 @@
+#include "common.h"
+
+#include <sys/select.h>
+
+int main(int argc, char** argv) {
+#if !defined(__clang__)
+  fd_set rfds;
+
+  CHK_FAIL_START
+  select(1337, &rfds, NULL, NULL, NULL);
+  CHK_FAIL_END
+
+  puts((const char*)&rfds);
+#endif
+  return ret;
+}


### PR DESCRIPTION
This is unlikely to be used, since fd_set is
usually manipulated by macros, but it doesn't hurt to add a simple comparison.