### PR TITLE
Do not use static inline for C++ to avoid ODR violations

### DIFF
--- a/include/fortify-headers.h
+++ b/include/fortify-headers.h
@@ -39,8 +39,13 @@
 
 /* clang uses overloads; see https://github.com/llvm/llvm-project/issues/53516 */
 /* we can't use extern inline with overloads without making them external */
+#ifdef __cplusplus
+#define _FORTIFY_INLINE __inline__ \
+        __attribute__((__always_inline__,__artificial__,__overloadable__))
+#else
 #define _FORTIFY_INLINE static __inline__ \
 	__attribute__((__always_inline__,__artificial__,__overloadable__))
+#endif
 
 #else /* !__clang__ */
 


### PR DESCRIPTION
Fixes https://github.com/jvoisin/fortify-headers/issues/31