### PR TITLE
fix typo for __builtin_memcpy

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -41,7 +41,7 @@ extern "C" {
 
 __fh_access(write_only, 1, 3)
 __fh_access(read_only, 2, 3)
-#if __has_builtin(__builtin_mempcpy)
+#if __has_builtin(__builtin_memcpy)
 __diagnose_as_builtin(__builtin_memcpy, 1, 2, 3)
 #endif
 _FORTIFY_FN(memcpy) void *memcpy(void * _FORTIFY_POS0 __od,


### PR DESCRIPTION
(or at least it doesn't seem to be intended since mempcpy is below)