### PR TITLE
Fix false-positives for stpncpy/strncpy

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -189,11 +189,12 @@ _FORTIFY_FN(stpncpy) char *stpncpy(char * _FORTIFY_POS0 __d, const char *__s,
 #if __has_builtin(__builtin___stpncpy_chk) && USE_NATIVE_CHK
 	return __builtin___stpncpy_chk(__d, __s, __n, __fh_bos(__d, 0));
 #else
-	if (__fh_overlap(__d, __s, __n))
+	__fh_size_t __len_s = strlen(__s) + 1;
+	if (__fh_overlap(__d, __s, (__len_s < __n)? __len_s: __n))
 		__builtin_trap();
 
 	__fh_size_t __b = __fh_bos(__d, 0);
-	if (__n > __b && strlen(__s) + 1 > __b)
+	if (__n > __b && __len_s > __b)
 		__builtin_trap();
 	return __orig_stpncpy(__d, __s, __n);
 #endif
@@ -290,7 +291,8 @@ _FORTIFY_FN(strncpy) char *strncpy(char * _FORTIFY_POS0 __d,
 #if __has_builtin(__builtin___strncpy_chk) && USE_NATIVE_CHK
 	return __builtin___strncpy_chk(__d, __s, __n, __fh_bos(__d, 0));
 #else
-	if (__fh_overlap(__d, __s, __n))
+	__fh_size_t __len_s = strlen(__s) + 1;
+	if (__fh_overlap(__d, __s, (__len_s < __n)? __len_s: __n))
 		__builtin_trap();
 
 	__fh_size_t __b = __fh_bos(__d, 0);

--- a/tests/test_stpncpy_overwrite_over.c
+++ b/tests/test_stpncpy_overwrite_over.c
@@ -6,6 +6,9 @@ int main(int argc, char** argv) {
   char buffer[9] = {'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', '\0'};
   puts(buffer);
 
+  stpncpy(buffer, buffer+5, 3);
+  puts(buffer);
+
   CHK_FAIL_START
   stpncpy(buffer+1, buffer, 5);
   CHK_FAIL_END

--- a/tests/test_stpncpy_overwrite_under.c
+++ b/tests/test_stpncpy_overwrite_under.c
@@ -6,6 +6,9 @@ int main(int argc, char** argv) {
   char buffer[9] = {'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', '\0'};
   puts(buffer);
 
+  stpncpy(buffer+5, buffer, 2);
+  puts(buffer);
+
   CHK_FAIL_START
   stpncpy(buffer-1, buffer, 5);
   CHK_FAIL_END

--- a/tests/test_strncat_dynamic_write.c
+++ b/tests/test_strncat_dynamic_write.c
@@ -4,6 +4,10 @@
 
 int main(int argc, char** argv) {
   char buffer[8] = {0};
+
+  strncat(buffer, "1", 50);
+  puts(buffer);
+
   strncat(buffer, "1234567", 5);
   puts(buffer);
 

--- a/tests/test_strncat_static_write.c
+++ b/tests/test_strncat_static_write.c
@@ -4,6 +4,10 @@
 
 int main(int argc, char** argv) {
   char buffer[8] = {0};
+
+  strncat(buffer, "1", 50);
+  puts(buffer);
+
   strncat(buffer, "1234567", 5);
   puts(buffer);
 

--- a/tests/test_strncpy_overwrite_over.c
+++ b/tests/test_strncpy_overwrite_over.c
@@ -6,6 +6,9 @@ int main(int argc, char** argv) {
   char buffer[9] = {'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', '\0'};
   puts(buffer);
 
+  strncpy(buffer+4, buffer, 1);
+  puts(buffer);
+
   CHK_FAIL_START
   strncpy(buffer+1, buffer, 5);
   CHK_FAIL_END

--- a/tests/test_strncpy_overwrite_under.c
+++ b/tests/test_strncpy_overwrite_under.c
@@ -6,6 +6,9 @@ int main(int argc, char** argv) {
   char buffer[9] = {'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', '\0'};
   puts(buffer);
 
+  strncpy(buffer, buffer+6, 1);
+  puts(buffer);
+
   CHK_FAIL_START
   strncpy(buffer-1, buffer, 5);
   CHK_FAIL_END


### PR DESCRIPTION
> They check overlap across the whole range of the given length, but the given
length is not what will actually be copied, rather it's the maximum length (if src is shorter, only length of src will be copied). This triggers false positives and traps where it shouldn't (e.g. in ICU tests).

Reported-by: q66