### PR TITLE
Use const fd_set for FD_ISSET

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -50,7 +50,7 @@ _STI void __fortify_FD_SET(int __f, fd_set * _FORTIFY_POS0 __s)
 	FD_SET(__f, __s);
 }
 
-_STI int __fortify_FD_ISSET(int __f, fd_set * _FORTIFY_POS0 __s)
+_STI int __fortify_FD_ISSET(int __f, const fd_set * _FORTIFY_POS0 __s)
 {
 	__fh_size_t __b = __fh_bos(__s, 0);
 


### PR DESCRIPTION
This fixes invalid conversion errors when the fd_set is defined as const.

fixes https://github.com/jvoisin/fortify-headers/issues/66