### PR TITLE
Change access of first fgets argument to write_only

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -37,7 +37,7 @@ extern "C" {
 #undef snprintf
 #undef sprintf
 
-__fortify_access(read_write, 1, 2)
+__fortify_access(write_only, 1, 2)
 __fortify_access(read_only, 3)
 _FORTIFY_FN(fgets) char *fgets(char * _FORTIFY_POS0 __s, int __n, FILE *__f)
 {


### PR DESCRIPTION
I assume this was just a typo and not intentional. Found through this warning:
```
In file included from ./include/fossil-scm/util.h:24,
                 from ./include/fossil-scm/core.h:22,
                 from ./include/fossil-scm/sync.h:21,
                 from ./src/sc.c:17:
In function 'fgets',
    inlined from 'fsl_sc_popen_xRead' at ./src/sc.c:522:20:
/usr/include/fortify/stdio.h:48:16: error: 'buf' may be used uninitialized [-Werror=maybe-uninitialized]
   48 |         return __orig_fgets(__s, __n, __f);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/fortify/stdio.h:26:
/usr/include/fortify/stdio.h: In function 'fsl_sc_popen_xRead':
/usr/include/fortify/stdio.h:42:1: note: in a call to '__orig_fgets' declared with attribute 'access (read_write, 1, 2)' here
   42 | _FORTIFY_FN(fgets) char *fgets(char * _FORTIFY_POS0 __s, int __n, FILE *__f)
      | ^~~~~~~~~~~
./src/sc.c:499:21: note: 'buf' declared here
  499 |       unsigned char buf[Sz];
      |                     ^~~
```

Fixes bf242b15e1f7